### PR TITLE
fix: add first p as description if there is no in front-matter

### DIFF
--- a/app/server/plugins/content.ts
+++ b/app/server/plugins/content.ts
@@ -5,10 +5,6 @@ export default defineNitroPlugin((nitroApp) => {
       if (file.body?.children?.[0]?.tag === 'h1') {
         file.body.children.shift()
       }
-      // Only if there is no description in front-matter
-      if (!file.description && file.body?.children?.[0]?.tag === 'p') {
-        file.body.children.shift()
-      }
       // Handle GitHub flavoured markdown blockquotes
       // https://github.com/orgs/community/discussions/16925
       for (const node of (file.body?.children || [])) {

--- a/app/server/plugins/content.ts
+++ b/app/server/plugins/content.ts
@@ -5,7 +5,8 @@ export default defineNitroPlugin((nitroApp) => {
       if (file.body?.children?.[0]?.tag === 'h1') {
         file.body.children.shift()
       }
-      if (file.body?.children?.[0]?.tag === 'p') {
+      // Only if there is no description in front-matter
+      if (!file.description && file.body?.children?.[0]?.tag === 'p') {
         file.body.children.shift()
       }
       // Handle GitHub flavoured markdown blockquotes


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #18

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
If there is ~already~ (there is always a description) a description in the front-matter, we do not need to remove the first `p` tag.

For the title, it make more sens since the first `h1` and the title in the front-matter must be the same.

see https://github.com/unjs/docs/issues/18#issuecomment-1911659965

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
