### PR TITLE
animate mismatching star numbers

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -18,7 +18,9 @@ const stars = useState('stars', () => cachedStars.value)
 
 onMounted(async () => {
   try {
-    const { stargazers_count } = await $fetch<{ stargazers_count: number }>(`https://api.github.com/repos/unjs/crossws`)
+    const { stargazers_count } = await $fetch<{ stargazers_count: number }>(
+      `https://api.github.com/repos/${appConfig.docs.github}`,
+    )
     let timeSlice = 1000 / (stargazers_count - stars.value)
     while (stars.value < stargazers_count) {
       stars.value++

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -5,7 +5,7 @@ const navigation = inject<NavItem[]>('navigation', [])
 
 const appConfig = useAppConfig()
 
-const [{ data: stars }, { data: tag }] = await Promise.all([
+const [{ data: cachedStars }, { data: tag }] = await Promise.all([
   useFetch(`https://ungh.cc/repos/${appConfig.docs.github}`, {
     transform: (data: any) => data.repo.stars as number,
   }),
@@ -13,6 +13,19 @@ const [{ data: stars }, { data: tag }] = await Promise.all([
     transform: (data: any) => data.release.tag as string,
   }),
 ])
+
+const stars = useState('stars', () => cachedStars.value)
+
+onMounted(async () => {
+  try {
+    const { stargazers_count } = await $fetch<{ stargazers_count: number }>(`https://api.github.com/repos/unjs/crossws`)
+    let timeSlice = 1000 / (stargazers_count - stars.value)
+    while (stars.value < stargazers_count) {
+      stars.value++
+      await new Promise((resolve) => setTimeout(resolve, timeSlice))
+    }
+  } catch {}
+})
 </script>
 
 <template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

ungh.cc stars are cached for a while and on top of it we pretender docs.

This uses an animation to make it feel better and also show latest number.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
